### PR TITLE
[FIX] Rename brainspell to metacurious

### DIFF
--- a/brainspell/index.html
+++ b/brainspell/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>Brainspell</title>
+    <title>metaCurious</title>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
The webpage title was still `brainspell` ! This patches it to read `metaCurious`. We should add a favicon of the dog, next !