### PR TITLE
Making the hostname dynamic and more easily interchangeable

### DIFF
--- a/brainspell/src/App.vue
+++ b/brainspell/src/App.vue
@@ -132,6 +132,8 @@ import 'bootstrap-vue/dist/bootstrap-vue.css';
 import '../node_modules/font-awesome/css/font-awesome.min.css';
 import auth from './lib/auth';
 
+Vue.prototype.$hostname = "https://brainspell.herokuapp.com";
+
 // explicit installation required in module environments
 
 Vue.use(BootstrapVue);
@@ -185,7 +187,7 @@ export default {
       const key = auth.getKey();
       // Get the user's collections
       this.pendingCollection = true;
-      axios.get(`https://brainspell.herokuapp.com/json/v2/get-user-collections?key=${key}&github_token=${token}&contributors=0`)
+      axios.get(`${this.$hostname}/json/v2/get-user-collections?key=${key}&github_token=${token}&contributors=0`)
            .then((resp) => {
              console.log('response on get user collections', resp);
              this.allCollections = resp.data.collections;
@@ -242,7 +244,7 @@ export default {
         globalData.experiments.push(entry);
       });
       const contents = JSON.stringify(globalData);
-      axios.post(`https://brainspell.herokuapp.com/json/v2/edit-global-article?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${data.pmid}&edit_contents=${contents}`); /* .then((resp) => {
+      axios.post(`${this.$hostname}/json/v2/edit-global-article?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${data.pmid}&edit_contents=${contents}`); /* .then((resp) => {
         //console.log('sent global', resp);
       }); */
       // const data = this.$refs.routerView.info;
@@ -275,7 +277,7 @@ export default {
       };
 
       const querystring = qs.stringify(localData);
-      axios.post(`https://brainspell.herokuapp.com/json/v2/edit-local-article?${querystring}`).then((resp) => {
+      axios.post(`${this.$hostname}/json/v2/edit-local-article?${querystring}`).then((resp) => {
         console.log('local response', resp);
         this.savePending = false;
         this.needsSave = false;

--- a/brainspell/src/App.vue
+++ b/brainspell/src/App.vue
@@ -107,6 +107,7 @@
 
     <div class="router">
       <router-view :userInfo="userInfo" :isAuthenticated="isAuthenticated"
+        :hostname="hostname"
         :currentCollection="currentCollection" :auth_tokens="auth_tokens"
         :allCollections="allCollections"
         v-on:updateCollection="updateCollections"
@@ -132,7 +133,6 @@ import 'bootstrap-vue/dist/bootstrap-vue.css';
 import '../node_modules/font-awesome/css/font-awesome.min.css';
 import auth from './lib/auth';
 
-Vue.prototype.$hostname = "https://brainspell.herokuapp.com";
 
 // explicit installation required in module environments
 
@@ -158,6 +158,7 @@ export default {
       canEdit: false,
       needsSave: false,
       savePending: false,
+      hostname: "https://brainspell.herokuapp.com",
     };
   },
 
@@ -187,7 +188,7 @@ export default {
       const key = auth.getKey();
       // Get the user's collections
       this.pendingCollection = true;
-      axios.get(`${this.$hostname}/json/v2/get-user-collections?key=${key}&github_token=${token}&contributors=0`)
+      axios.get(`${this.hostname}/json/v2/get-user-collections?key=${key}&github_token=${token}&contributors=0`)
            .then((resp) => {
              console.log('response on get user collections', resp);
              this.allCollections = resp.data.collections;
@@ -244,7 +245,7 @@ export default {
         globalData.experiments.push(entry);
       });
       const contents = JSON.stringify(globalData);
-      axios.post(`${this.$hostname}/json/v2/edit-global-article?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${data.pmid}&edit_contents=${contents}`); /* .then((resp) => {
+      axios.post(`${this.hostname}/json/v2/edit-global-article?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${data.pmid}&edit_contents=${contents}`); /* .then((resp) => {
         //console.log('sent global', resp);
       }); */
       // const data = this.$refs.routerView.info;
@@ -277,7 +278,7 @@ export default {
       };
 
       const querystring = qs.stringify(localData);
-      axios.post(`${this.$hostname}/json/v2/edit-local-article?${querystring}`).then((resp) => {
+      axios.post(`${this.hostname}/json/v2/edit-local-article?${querystring}`).then((resp) => {
         console.log('local response', resp);
         this.savePending = false;
         this.needsSave = false;

--- a/brainspell/src/components/CreateCollection.vue
+++ b/brainspell/src/components/CreateCollection.vue
@@ -185,6 +185,7 @@ import 'vue-form-wizard/dist/vue-form-wizard.min.css';
 import 'ti-icons/css/themify-icons.css';
 import Descriptors from './Descriptors';
 
+
 Vue.use(VueFormWizard);
 
 const Textfield = {
@@ -358,10 +359,10 @@ export default {
         key: this.auth_tokens.api_key });
       // const help = `https://brainspell.herokuapp.com/json/v2/create-collection?github_token=${this.auth_tokens.github_access_token}&inclusion_criteria=${JSON.stringify(this.incCriteria)}&exclusion_criteria=${JSON.stringify(this.excCriteria)}&collection_name=${this.name}&description=${this.description}&search_strings=${JSON.stringify(this.searchStr)}&tags=${JSON.stringify(this.descriptors)}&key=${this.auth_tokens.api_key}`
       // console.log(querystring);
-      axios.post(`https://brainspell.herokuapp.com/json/v2/create-collection?${querystring}`)
+      axios.post(`${this.$hostname}/json/v2/create-collection?${querystring}`)
         .then(() => {
           // console.log('resp is', response);
-          axios.post(`https://brainspell.herokuapp.com/json/v2/add-to-collection?${querystring2}`).then((resp2) => {
+          axios.post(`${this.$hostname}/json/v2/add-to-collection?${querystring2}`).then((resp2) => {
             console.log('resp2', resp2);
             this.loading = false;
             this.yay = true;

--- a/brainspell/src/components/CreateCollection.vue
+++ b/brainspell/src/components/CreateCollection.vue
@@ -212,7 +212,7 @@ const Textfield = {
 };
 export default {
   name: 'collection',
-  props: ['isAuthenticated', 'auth_tokens', 'userInfo'],
+  props: ['isAuthenticated', 'auth_tokens', 'userInfo', 'hostname'],
   data() {
     return {
       incFields: ['Criteria', 'delete'],
@@ -359,10 +359,10 @@ export default {
         key: this.auth_tokens.api_key });
       // const help = `https://brainspell.herokuapp.com/json/v2/create-collection?github_token=${this.auth_tokens.github_access_token}&inclusion_criteria=${JSON.stringify(this.incCriteria)}&exclusion_criteria=${JSON.stringify(this.excCriteria)}&collection_name=${this.name}&description=${this.description}&search_strings=${JSON.stringify(this.searchStr)}&tags=${JSON.stringify(this.descriptors)}&key=${this.auth_tokens.api_key}`
       // console.log(querystring);
-      axios.post(`${this.$hostname}/json/v2/create-collection?${querystring}`)
+      axios.post(`${this.hostname}/json/v2/create-collection?${querystring}`)
         .then(() => {
           // console.log('resp is', response);
-          axios.post(`${this.$hostname}/json/v2/add-to-collection?${querystring2}`).then((resp2) => {
+          axios.post(`${this.hostname}/json/v2/add-to-collection?${querystring2}`).then((resp2) => {
             console.log('resp2', resp2);
             this.loading = false;
             this.yay = true;

--- a/brainspell/src/components/EditCollection.vue
+++ b/brainspell/src/components/EditCollection.vue
@@ -161,7 +161,7 @@ const Textfield = {
 };
 export default {
   name: 'collection',
-  props: ['isAuthenticated', 'auth_tokens', 'userInfo'],
+  props: ['isAuthenticated', 'auth_tokens', 'userInfo', 'hostname'],
   data() {
     return {
       showDismissibleAlert: false,
@@ -269,7 +269,7 @@ export default {
         key: this.auth_tokens.api_key });
       // const help = `https://brainspell.herokuapp.com/json/v2/create-collection?github_token=${this.auth_tokens.github_access_token}&inclusion_criteria=${JSON.stringify(this.incCriteria)}&exclusion_criteria=${JSON.stringify(this.excCriteria)}&collection_name=${this.name}&description=${this.description}&search_strings=${JSON.stringify(this.searchStr)}&tags=${JSON.stringify(this.descriptors)}&key=${this.auth_tokens.api_key}`
       // console.log(querystring);
-      axios.post(`${this.$hostname}/json/v2/create-collection?${querystring}`)
+      axios.post(`${this.hostname}/json/v2/create-collection?${querystring}`)
         .then(() => {
           // console.log('resp is', response);
         })

--- a/brainspell/src/components/EditCollection.vue
+++ b/brainspell/src/components/EditCollection.vue
@@ -269,7 +269,7 @@ export default {
         key: this.auth_tokens.api_key });
       // const help = `https://brainspell.herokuapp.com/json/v2/create-collection?github_token=${this.auth_tokens.github_access_token}&inclusion_criteria=${JSON.stringify(this.incCriteria)}&exclusion_criteria=${JSON.stringify(this.excCriteria)}&collection_name=${this.name}&description=${this.description}&search_strings=${JSON.stringify(this.searchStr)}&tags=${JSON.stringify(this.descriptors)}&key=${this.auth_tokens.api_key}`
       // console.log(querystring);
-      axios.post(`https://brainspell.herokuapp.com/json/v2/create-collection?${querystring}`)
+      axios.post(`${this.$hostname}/json/v2/create-collection?${querystring}`)
         .then(() => {
           // console.log('resp is', response);
         })

--- a/brainspell/src/components/Home.vue
+++ b/brainspell/src/components/Home.vue
@@ -57,6 +57,7 @@ import axios from 'axios';
 
 export default {
   name: 'Home',
+  props: ['hostname'],
   data() {
     return {
       query: null,
@@ -76,7 +77,7 @@ export default {
       }
     },
     randomQuery() {
-      axios.get(`${this.$hostname}/json/random-query`).then((res) => {
+      axios.get(`${this.hostname}/json/random-query`).then((res) => {
         // console.log('result is', res);
         this.articles = res.data.articles;
         this.randomPending = false;

--- a/brainspell/src/components/Home.vue
+++ b/brainspell/src/components/Home.vue
@@ -76,7 +76,7 @@ export default {
       }
     },
     randomQuery() {
-      axios.get('https://brainspell.herokuapp.com/json/random-query').then((res) => {
+      axios.get(`${this.$hostname}/json/random-query`).then((res) => {
         // console.log('result is', res);
         this.articles = res.data.articles;
         this.randomPending = false;

--- a/brainspell/src/components/Search.vue
+++ b/brainspell/src/components/Search.vue
@@ -78,7 +78,7 @@ export default {
   methods: {
     fetchData() {
       this.loading = true;
-      axios.get(`https://brainspell.herokuapp.com/json/query?q=${this.$route.params.query}&start=${this.start}`).then((resp) => {
+      axios.get(`${this.$hostname}/json/query?q=${this.$route.params.query}&start=${this.start}`).then((resp) => {
         this.articles = this.articles.concat(resp.data.articles);
         if (resp.data.articles.length !== 10) {
           this.end = true;

--- a/brainspell/src/components/Search.vue
+++ b/brainspell/src/components/Search.vue
@@ -61,6 +61,7 @@ import axios from 'axios';
 
 export default {
   name: 'search',
+  props : ['hostname'],
   data() {
     return {
       articles: [],
@@ -78,7 +79,7 @@ export default {
   methods: {
     fetchData() {
       this.loading = true;
-      axios.get(`${this.$hostname}/json/query?q=${this.$route.params.query}&start=${this.start}`).then((resp) => {
+      axios.get(`${this.hostname}/json/query?q=${this.$route.params.query}&start=${this.start}`).then((resp) => {
         this.articles = this.articles.concat(resp.data.articles);
         if (resp.data.articles.length !== 10) {
           this.end = true;

--- a/brainspell/src/components/ViewArticle.vue
+++ b/brainspell/src/components/ViewArticle.vue
@@ -243,7 +243,7 @@
         if (this.currentCollection) {
           this.localPending = true;
           this.$emit('savePending', true);
-          axios.get(`https://brainspell.herokuapp.com/json/v2/get-article-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}`).then((resp) => {
+          axios.get(`${this.$hostname}/json/v2/get-article-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}`).then((resp) => {
             this.isExcluded = !!resp.data.article_info.excluded_flag;
             this.excReason = resp.data.article_info.exclusion_reason || '';
             this.localPending = false;
@@ -269,7 +269,7 @@
       addToCollection() {
         // console.log('sending request...');
         this.addPending = true;
-        axios.get(`https://brainspell.herokuapp.com/json/v2/add-to-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&unmapped_pmids=${JSON.stringify([this.pmid])}&collection_name=${this.currentCollection.name}`)
+        axios.get(`${this.$hostname}/json/v2/add-to-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&unmapped_pmids=${JSON.stringify([this.pmid])}&collection_name=${this.currentCollection.name}`)
           .then(() => {
             // console.log('success, added', resp);
             this.addPending = false;
@@ -282,7 +282,7 @@
       includeInCollection(e) {
         e.preventDefault();
         this.addPending = true;
-        axios.get(`https://brainspell.herokuapp.com/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=0`)
+        axios.get(`${this.$hostname}/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=0`)
           .then(() => {
             // console.log('success, added', resp);
             this.addPending = false;
@@ -293,7 +293,7 @@
 
       excludeFromCollection() {
         this.addPending = true;
-        axios.get(`https://brainspell.herokuapp.com/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=1`)
+        axios.get(`${this.$hostname}/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=1`)
           .then(() => {
             // console.log('success, added', resp);
             this.addPending = false;
@@ -330,7 +330,7 @@
       },
       fetchData() {
         this.pmid = this.$route.params.id;
-        axios.get(`https://brainspell.herokuapp.com/json/article?pmid=${this.$route.params.id}`)
+        axios.get(`${this.$hostname}/json/article?pmid=${this.$route.params.id}`)
         .then((resp) => {
           this.info = resp.data;
           // this.articleURL = `http://dx.doi.org/${this.info.doi}`;

--- a/brainspell/src/components/ViewArticle.vue
+++ b/brainspell/src/components/ViewArticle.vue
@@ -159,7 +159,7 @@
 
   export default {
     name: 'ViewArticle',
-    props: ['currentCollection', 'isAuthenticated', 'auth_tokens', 'pendingCollection'],
+    props: ['currentCollection', 'isAuthenticated', 'auth_tokens', 'pendingCollection', 'hostname'],
     data() {
       return {
         pmid: null,
@@ -243,7 +243,7 @@
         if (this.currentCollection) {
           this.localPending = true;
           this.$emit('savePending', true);
-          axios.get(`${this.$hostname}/json/v2/get-article-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}`).then((resp) => {
+          axios.get(`${this.hostname}/json/v2/get-article-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}`).then((resp) => {
             this.isExcluded = !!resp.data.article_info.excluded_flag;
             this.excReason = resp.data.article_info.exclusion_reason || '';
             this.localPending = false;
@@ -269,7 +269,7 @@
       addToCollection() {
         // console.log('sending request...');
         this.addPending = true;
-        axios.get(`${this.$hostname}/json/v2/add-to-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&unmapped_pmids=${JSON.stringify([this.pmid])}&collection_name=${this.currentCollection.name}`)
+        axios.get(`${this.hostname}/json/v2/add-to-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&unmapped_pmids=${JSON.stringify([this.pmid])}&collection_name=${this.currentCollection.name}`)
           .then(() => {
             // console.log('success, added', resp);
             this.addPending = false;
@@ -282,7 +282,7 @@
       includeInCollection(e) {
         e.preventDefault();
         this.addPending = true;
-        axios.get(`${this.$hostname}/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=0`)
+        axios.get(`${this.hostname}/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=0`)
           .then(() => {
             // console.log('success, added', resp);
             this.addPending = false;
@@ -293,7 +293,7 @@
 
       excludeFromCollection() {
         this.addPending = true;
-        axios.get(`${this.$hostname}/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=1`)
+        axios.get(`${this.hostname}/json/v2/toggle-exclusion-from-collection?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${this.pmid}&collection_name=${this.currentCollection.name}&exclusion_criterion=${this.excReason}&exclude=1`)
           .then(() => {
             // console.log('success, added', resp);
             this.addPending = false;
@@ -330,7 +330,7 @@
       },
       fetchData() {
         this.pmid = this.$route.params.id;
-        axios.get(`${this.$hostname}/json/article?pmid=${this.$route.params.id}`)
+        axios.get(`${this.hostname}/json/article?pmid=${this.$route.params.id}`)
         .then((resp) => {
           this.info = resp.data;
           // this.articleURL = `http://dx.doi.org/${this.info.doi}`;


### PR DESCRIPTION
I'm swapping out the hardcoded brainspell.herokuapp.com hostname for `this.$hostname` to make it a little easier to test on localhost. 


I checked the functionality on the main pages and they seemed normal though it might warrant a second pass. I also assumed that app.vue was the entry point here so setting the hostname property here seemed logical, but again let me know if I'm wrong. 