### PR TITLE
Implementing Websockets for Heartbeat messages

### DIFF
--- a/brainspell/src/App.vue
+++ b/brainspell/src/App.vue
@@ -181,6 +181,7 @@ export default {
       const key = auth.getKey();
       // Get the user's collections
       this.pendingCollection = true;
+
       axios.get(`${this.hostname}/json/v2/get-user-collections?key=${key}&github_token=${token}&contributors=0&cache=1`)
            .then((resp) => {
              console.log('response on get user collections', resp);
@@ -239,7 +240,6 @@ export default {
         globalData.experiments.push(entry);
       });
       const contents = JSON.stringify(globalData.experiments);
-      console.log(globalData.experiments);
       axios.post(`${this.hostname}/json/v2/edit-global-article?github_token=${this.auth_tokens.github_access_token}&key=${this.auth_tokens.api_key}&pmid=${data.pmid}&experiments=${contents}&subjects=${globalData.nsubjects}`); /* .then((resp) => {
         //console.log('sent global', resp);
       }); */

--- a/brainspell/src/components/ViewArticle.vue
+++ b/brainspell/src/components/ViewArticle.vue
@@ -190,7 +190,7 @@
 
           exists = exists.concat(exists2);
 
-          if (exists != undefined) {
+          if (exists !== undefined) {
             this.$emit('setEdit', exists.length);
             return exists.length;
           }


### PR DESCRIPTION
**Summary**
We had some issues with heroku timeouts for long running computation so we are now sending heartbeat messages from the server to the client specifically for the `forcePullFromGithub` endpoint. This diff handles the updated server response through a persistent websocket which silently ignores `loading` messages. 

**Test Plan**
I evaluated this on localhost against the new server logic and verified that the new data is loaded from github. I was not able to validate the specific heroku router limitations on localhost, but conventional practices say that this should resolve the issue. 


**Notes**
Don't merge this until the corresponding server changes (https://github.com/OpenNeuroLab/brainspell-neo/pull/72) have been merged as the websocket endpoint does not currently exist yet. 